### PR TITLE
Replace godoc.org link with pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go workflow status badge](https://github.com/xorcare/pointer/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/xorcare/pointer/actions/workflows/go.yml)
 [![codecov](https://codecov.io/gh/xorcare/pointer/badge.svg?branch=main)](https://codecov.io/gh/xorcare/pointer)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xorcare/pointer)](https://goreportcard.com/report/github.com/xorcare/pointer)
-[![GoDoc](https://godoc.org/github.com/xorcare/pointer?status.svg)](https://godoc.org/github.com/xorcare/pointer)
+[![GoDoc](https://godoc.org/github.com/xorcare/pointer?status.svg)](https://pkg.go.dev/github.com/xorcare/pointer)
 
 Package pointer contains helper routines for simplifying the creation
 of optional fields of basic type.


### PR DESCRIPTION
pkg.go.dev - replaces the old documentation portal, in this regard, the
link is updated.

https://go.dev/blog/godoc.org-redirect