### PR TITLE
Make generic method for creating pointers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,7 @@ jobs:
         - '1.16'
         - '1.17'
         - '1.18'
+        - '1.19'
     steps:
     - uses: actions/checkout@v3
     - name: "Set up Go:${{ matrix.go }}"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ of optional fields of basic type.
 go get github.com/xorcare/pointer
 ```
 
+## Generics
+
+Starting with Go 18+, you can use the `Of` method to get pointers to values of any types.
+
 ## Examples
 
 Examples of using the library are presented on [godoc.org][GDE]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/xorcare/pointer
 
-go 1.13
+go 1.18

--- a/pointer_118.go
+++ b/pointer_118.go
@@ -1,0 +1,14 @@
+// Copyright © 2022 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.18
+// +build go1.18
+
+package pointer
+
+// Of is a helper routine that allocates a new any value
+// to store v and returns a pointer to it.
+func Of[Value any](v Value) *Value {
+	return &v
+}

--- a/pointer_118_test.go
+++ b/pointer_118_test.go
@@ -1,0 +1,41 @@
+// Copyright © 2022 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.18
+// +build go1.18
+
+package pointer
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestOf(t *testing.T) {
+	equal(t, true, *Of(true))
+	equal(t, false, *Of(false))
+	equal(t, byte(1), *Of(byte(1)))
+	equal(t, []byte{1}, *Of([]byte{1}))
+	equal(t, complex64(1), *Of(complex64(1)))
+	equal(t, complex128(1), *Of(complex128(1)))
+	equal(t, float32(1.1), *Of(float32(1.1)))
+	equal(t, float64(1.1), *Of(float64(1.1)))
+	equal(t, int(1), *Of(int(1)))
+	equal(t, int8(1), *Of(int8(1)))
+	equal(t, int16(1), *Of(int16(1)))
+	equal(t, int32(1), *Of(int32(1)))
+	equal(t, int64(1), *Of(int64(1)))
+	equal(t, rune(1), *Of(rune(1)))
+	equal(t, string("pointer"), *Of(string("pointer")))
+	equal(t, uint(1), *Of(uint(1)))
+	equal(t, uint8(1), *Of(uint8(1)))
+	equal(t, uint16(1), *Of(uint16(1)))
+	equal(t, uint32(1), *Of(uint32(1)))
+	equal(t, uint64(1), *Of(uint64(1)))
+	equal(t, uintptr(1), *Of(uintptr(1)))
+	equal(t, time.Time{}.Add(time.Hour), *Of(time.Time{}.Add(time.Hour)))
+	equal(t, 127*time.Hour, *Of(127 * time.Hour))
+	equal(t, os.Interrupt, *Of(os.Interrupt))
+}


### PR DESCRIPTION
This method will allow you to systematically replace the `Any` method
and will look more concise while allowing you to create pointers to
values of any type.