### PR TITLE
Deprecate package for Go 1.26+ (new(expr) replaces helpers)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,18 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go:
-          - "1.11"
-          - "1.12"
-          - "1.13"
-          - "1.14"
-          - "1.15"
-          - "1.16"
-          - "1.17"
-          - "1.18"
-          - "1.19"
-          - "1.20"
-          - "1.21"
-          - "1.22"
+          - ">=1.26.0"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go:${{ matrix.go }}
@@ -46,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: ">=1.26.0"
       - name: Make check
         run: make check
       - uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 Package pointer contains helper routines for simplifying the creation
 of optional fields of basic type.
 
+## Deprecated in Go 1.26+
+
+Starting with **Go 1.26**, the built-in `new` function supports expressions:
+`p := new(42)` or `&Age: new(calculateAge())`.
+
+This replaces all helpers like `pointer.Of[Value](v)` or type-specific `pointer.Int(1)`.
+**No need to use this package anymore — copy the generics version locally only if stuck on Go 1.18–1.25.**
+
 ## A little copying is better than a little dependency
 
 With the advent of generics in go 1.18, using this library in your code is

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+// Deprecated: Use built-in `new(expr)` in Go 1.26+ instead of pointer helpers.
+// See https://tip.golang.org/doc/go1.26#language
 module github.com/xorcare/pointer
 
-go 1.18
+go 1.26

--- a/pointer_126.go
+++ b/pointer_126.go
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.18 && !go1.26
+// Deprecated: Use built-in `new(expr)` in Go 1.26+.
+// Only for Go 1.18–1.25.
+//go:build go1.26
 
 package pointer
 
 // Of is a helper routine that allocates a new any value
 // to store v and returns a pointer to it.
 func Of[Value any](v Value) *Value {
-	return &v
+	return new(v)
 }


### PR DESCRIPTION
The end of yet another short story...